### PR TITLE
Simplify BootstrapExtensions

### DIFF
--- a/src/main/java/zone/dragon/dropwizard/BootstrapExtensions.java
+++ b/src/main/java/zone/dragon/dropwizard/BootstrapExtensions.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
@@ -17,40 +16,12 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Utility methods for interacting with the {@link Bundle bundles} and {@link ConfiguredBundle configured bundles} in a {@link Bootstrap}
+ * Utility methods for interacting with the {@link ConfiguredBundle configured bundles} in a {@link Bootstrap}
  */
 @Slf4j
 @UtilityClass
 public class BootstrapExtensions {
     private final Field CONFIGURED_BUNDLES_FIELD = getBootstrapField("configuredBundles");
-
-    /**
-     * Adds a {@link Bundle} to a {@link Bootstrap bootstrap} in an idempotent manner. Use this when multiple bundles may want a specific
-     * bundle as a dependency, but don't know if another bundle has already added it to the application.
-     *
-     * @param bootstrap
-     *     {@code Bootstrap} to which the bundle should be added
-     * @param bundleType
-     *     Type of the bundle to look for when verifying that it hasn't already been added to the {@code bootstrap}
-     * @param bundleSupplier
-     *     Supplier for the bundle if it has not already been added to the {@code bootstrap}
-     * @param <T>
-     *     Type of the bundle
-     *
-     * @return The first bundle of type {@code T} in the {@code bootstrap}
-     */
-    @Deprecated
-    <T extends Bundle> T addBundleIfNotExist(
-        @NonNull Bootstrap<?> bootstrap, @NonNull Class<T> bundleType, @NonNull Supplier<T> bundleSupplier
-    ) {
-        List<T> implementingBundles = getImplementingBundles(bootstrap, bundleType);
-        if (implementingBundles.isEmpty()) {
-            T bundle = bundleSupplier.get();
-            bootstrap.addBundle(bundle);
-            return bundle;
-        }
-        return implementingBundles.get(0);
-    }
 
     /**
      * Adds a {@link ConfiguredBundle} to a {@link Bootstrap bootstrap} in an idempotent manner. Use this when multiple bundles may want a
@@ -67,7 +38,7 @@ public class BootstrapExtensions {
      *
      * @return The first configured bundle of type {@code T} in the {@code bootstrap}
      */
-    <U extends Configuration, T extends ConfiguredBundle<U>> T addConfiguredBundleIfNotExist(
+    <U extends Configuration, T extends ConfiguredBundle<U>> T addBundleIfNotExist(
         @NonNull Bootstrap<U> bootstrap, @NonNull Class<T> bundleType, @NonNull Supplier<T> bundleSupplier
     ) {
         List<T> implementingBundles = getImplementingBundles(bootstrap, bundleType);
@@ -96,49 +67,22 @@ public class BootstrapExtensions {
     }
 
     /**
-     * Retrieves the list of {@link Bundle bundles} registered with a {@link Bootstrap}. Note, this does not return
-     * {@link ConfiguredBundle configured bundles}.
-     *
-     * @param bootstrap
-     *     {@code Bootstrap} from which to retrieve bundles
-     *
-     * @return The bundles in the {@code Bootstrap}
-     *
-     * @deprecated Use {@link #getConfiguredBundles(Bootstrap)} instead
-     *
-     * @see #getConfiguredBundles(Bootstrap)
-     */
-    @SuppressWarnings("unchecked")
-    @Deprecated
-    @SneakyThrows
-    List<Bundle> getBundles(@NonNull Bootstrap<?> bootstrap) {
-        return getConfiguredBundles(bootstrap)
-            .stream()
-            .filter(Bundle.class::isInstance)
-            .map(Bundle.class::cast)
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieves the list of {@link ConfiguredBundle configured bundles} registered with a {@link Bootstrap}. Note, this does not return
-     * {@link Bundle bundles}.
+     * Retrieves the list of {@link ConfiguredBundle configured bundles} registered with a {@link Bootstrap}.
      *
      * @param bootstrap
      *     {@code Bootstrap} from which to retrieve configured bundles
      *
      * @return The configured bundles in the {@code Bootstrap}
-     *
-     * @see #getBundles(Bootstrap)
      */
     @SuppressWarnings("unchecked")
     @SneakyThrows
-    <U extends Configuration> List<ConfiguredBundle<U>> getConfiguredBundles(@NonNull Bootstrap<U> bootstrap) {
+    <U extends Configuration> List<ConfiguredBundle<U>> getBundles(@NonNull Bootstrap<U> bootstrap) {
         return Collections.unmodifiableList((List<ConfiguredBundle<U>>) CONFIGURED_BUNDLES_FIELD.get(bootstrap));
     }
 
     /**
      * Return a filtered list of all bundles that have been added to {@link Bootstrap bootstrap} which implement the given {@code type}.
-     * This is useful for one bundle to interact with other bundles in the {@link Bundle#run(Environment) run} method.
+     * This is useful for one bundle to interact with other bundles in the {@link ConfiguredBundle#run(T,Environment) run} method.
      *
      * @param bootstrap
      *     {@code Bootstrap} from which to retrieve bundles.
@@ -147,12 +91,12 @@ public class BootstrapExtensions {
      * @param <T>
      *     Implemented type by which bundles should be filtered
      *
-     * @return A list of all {@link Bundle bundles} and {@link ConfiguredBundle configured bundles} which implement {@code type} and are
+     * @return A list of all {@link ConfiguredBundle configured bundles} which implement {@code type} and are
      * registered with the {@code bootstrap}
      */
     @SuppressWarnings("unchecked")
     <T> List<T> getImplementingBundles(@NonNull Bootstrap<?> bootstrap, @NonNull Class<T> type) {
-        return getConfiguredBundles(bootstrap)
+        return getBundles(bootstrap)
             .stream()
             .filter(bundle -> type.isAssignableFrom(bundle.getClass()))
             .map(type::cast)

--- a/src/main/java/zone/dragon/dropwizard/HK2Bundle.java
+++ b/src/main/java/zone/dragon/dropwizard/HK2Bundle.java
@@ -68,7 +68,7 @@ public class HK2Bundle<T extends Configuration> implements ConfiguredBundle<T> {
      */
     @SuppressWarnings("unchecked")
     public static <T extends Configuration> HK2Bundle<T> addTo(Bootstrap<T> bootstrap) {
-        return BootstrapExtensions.addConfiguredBundleIfNotExist(bootstrap, HK2Bundle.class, HK2Bundle::new);
+        return BootstrapExtensions.addBundleIfNotExist(bootstrap, HK2Bundle.class, HK2Bundle::new);
     }
 
     /**

--- a/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
+++ b/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
@@ -96,11 +96,6 @@ public class BootstrapExtensionsTest {
         assertThat(bundles).containsExactly(bundle);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testGetConfiguredBundlesWithNull() {
-        BootstrapExtensions.getBundles(null);
-    }
-
     @SuppressWarnings("unchecked")
     @Test
     public void testGetImplementingBundles() {

--- a/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
+++ b/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
@@ -90,7 +90,7 @@ public class BootstrapExtensionsTest {
         ConfiguredBundle bundle    = mock(ConfiguredBundle.class);
         bootstrap.addBundle(bundle);
         //
-        List<ConfiguredBundle<Configuration>> bundles = BootstrapExtensions.getConfiguredBundles(bootstrap);
+        List<ConfiguredBundle<Configuration>> bundles = BootstrapExtensions.getBundles(bootstrap);
         //
         assertThat(bundles).isNotNull();
         assertThat(bundles).containsExactly(bundle);
@@ -98,7 +98,7 @@ public class BootstrapExtensionsTest {
 
     @Test(expected = NullPointerException.class)
     public void testGetConfiguredBundlesWithNull() {
-        BootstrapExtensions.getConfiguredBundles(null);
+        BootstrapExtensions.getBundles(null);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
+++ b/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
@@ -29,7 +29,7 @@ public class BootstrapExtensionsTest {
     @Test
     public void testAddBundleIfNotExist() {
         Bundle       newBundle = mock(Bundle.class);
-        Bootstrap<?> bootstrap = new Bootstrap<>(null);
+        Bootstrap<Configuration> bootstrap = new Bootstrap<>(null);
         //
         Bundle addedBundle = BootstrapExtensions.addBundleIfNotExist(bootstrap, Bundle.class, () -> newBundle);
         //
@@ -56,7 +56,7 @@ public class BootstrapExtensionsTest {
     public void testAddBundleIfNotExistPreExisting() {
         Supplier<Bundle> bundleSupplier = mock(Supplier.class);
         Bundle           oldBundle      = mock(Bundle.class);
-        Bootstrap<?>     bootstrap      = new Bootstrap<>(null);
+        Bootstrap<Configuration>     bootstrap      = new Bootstrap<>(null);
         bootstrap.addBundle(oldBundle);
         //
         Bundle addedBundle = BootstrapExtensions.addBundleIfNotExist(bootstrap, Bundle.class, bundleSupplier);
@@ -68,7 +68,7 @@ public class BootstrapExtensionsTest {
 
     @Test
     public void testGetBundles() {
-        Bootstrap<?> bootstrap = new Bootstrap<>(null);
+        Bootstrap<Configuration> bootstrap = new Bootstrap<>(null);
         Bundle       bundle    = mock(Bundle.class);
         bootstrap.addBundle(bundle);
         //

--- a/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
+++ b/src/test/java/zone/dragon/dropwizard/BootstrapExtensionsTest.java
@@ -72,7 +72,7 @@ public class BootstrapExtensionsTest {
         Bundle       bundle    = mock(Bundle.class);
         bootstrap.addBundle(bundle);
         //
-        List<Bundle> bundles = BootstrapExtensions.getBundles(bootstrap);
+        List<ConfiguredBundle<Configuration>> bundles = BootstrapExtensions.getBundles(bootstrap);
         //
         assertThat(bundles).isNotNull();
         assertThat(bundles).containsExactly(bundle);


### PR DESCRIPTION
This removes the ConfiguredBundle/Bundle dichotomy from BootstrapExtensions to reduce confusion.