### PR TITLE
Exclude javax.servlet-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Exclude the `javax.servlet-api` being pulled in via jetty-server so that we're using exclusively `jakarta.*` dependencies.